### PR TITLE
Add skeleton pkdgrav3 interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,10 +201,15 @@ vr_option_defines(ZOOM_SIM                  HIGHRES)
 vr_option_defines(USE_LARGE_KDTREE          LARGETREE)
 
 vr_option_defines(USE_SWIFT_INTERFACE       SWIFTINTERFACE)
+vr_option_defines(USE_PKDGRAV3_INTERFACE    PKDGRAV3INTERFACE)
 vr_option_defines(LOG_SOURCE_LOCATION       VR_LOG_SOURCE_LOCATION)
 
 if (VR_USE_SWIFT_INTERFACE)
         list(APPEND VR_INCLUDE_DIRS ${SWIFT_INCLUDE_DIR})
+endif()
+
+if (VR_USE_PKDGRAV3_INTERFACE)
+        list(APPEND VR_INCLUDE_DIRS ${PKDGRAV3_INCLUDE_DIR})
 endif()
 
 

--- a/cmake/VRCompilationMessages.cmake
+++ b/cmake/VRCompilationMessages.cmake
@@ -71,7 +71,8 @@ macro(vr_compilation_summary)
         )
     vr_report("Simulation-specifics"
             "Used to run against simulations with a high resolution region" ZOOM_SIM
-            "Build library for integration into SWIFT Sim code " USE_SWIFT_INTERFACE)
+            "Build library for integration into SWIFT Sim code " USE_SWIFT_INTERFACE
+            "Build library for integration into PKDGRAV3 code " USE_PKDGRAV3_INTERFACE)
     vr_report("Others"
             "Calculate local density dist. only for particles in field objects" STRUCTURE_DEN
             "Like above, but use particles inside field objects only for calclation" HALO_DEN)

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -6,7 +6,7 @@ Developing |vr|
 |vr| is an freely available from `github <https://www.github.com/pelahi/VELOCIraptor-STF/>`_.
 It is in active development, with additions for hydrodynamical inputs, extra inputs and functionality being implemented.
 The code can also be called as a library for on-the-fly halo finding integration
-into any code. Currently there are hooks for `SWIFTSIM <https://gitlab.cosma.dur.ac.uk/swift/swiftsim/>`_.
+into any code. Currently there are hooks for `SWIFTSIM <https://gitlab.cosma.dur.ac.uk/swift/swiftsim/>`_ and PKDGRAV3.
 
 Integration into N-Body/Hydro
 =============================

--- a/doc/getting.rst
+++ b/doc/getting.rst
@@ -147,5 +147,8 @@ These can be passed to ``cmake``
     * Produce SWIFTSIM compatible library (executable still produced but does simply returns warning)
         | ``VR_USE_SWIFT_INTERFACE=ON``
         | ``CMAKE_CXX_FLAGS=-fPIC``
+    * Produce PKDGRAV3 compatible library (executable still produced but does simply returns warning)
+        | ``VR_USE_PKDGRAV3_INTERFACE=ON``
+        | ``CMAKE_CXX_FLAGS=-fPIC``
     * Enable debugging
         ``DEBUG=ON``

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,7 +16,7 @@ The repository also contains several associated analysis tools in python,
 example configuration files and analysis python scripts (and sample jupyter notebooks).
 The code can also be compiled as a library for on-the-fly halo finding within an
 N-body/hydrodynamnical code. Currently integration is limited to `SWIFTSIM <http://icc.dur.ac.uk/swift/>`_
-but extensions are in the works for other codes.
+and PKDGRAV3, but extensions are in the works for other codes.
 
 There is an associated halo merger tree code `TreeFrog <https://www.github.com/pelahi/TreeFrog/>`_ (also C++ MPI+OpenMP).
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ set(VR_SOURCES
     ramsesio.cxx
     search.cxx
     swiftinterface.cxx
+    pkdgrav3interface.cxx
     substructureproperties.cxx
     tipsyio.cxx
     ui.cxx

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -106,8 +106,8 @@ int run(int argc,char **argv)
 
     show_version_info(argc, argv);
 
-#ifdef SWIFTINTERFACE
-    cout<<"Built with SWIFT interface enabled when running standalone VELOCIraptor. Should only be enabled when running VELOCIraptor as a library from SWIFT. Exiting..."<<endl;
+#if defined(SWIFTINTERFACE) || defined(PKDGRAV3INTERFACE)
+    cout<<"Built with interface enabled when running standalone VELOCIraptor. Should only be enabled when running VELOCIraptor as a library. Exiting..."<<endl;
     exit(0);
 #endif
 

--- a/src/pkdgrav3interface.cxx
+++ b/src/pkdgrav3interface.cxx
@@ -1,0 +1,31 @@
+/*! \file pkdgrav3interface.cxx
+ *  \brief this file contains routines that allow the velociraptor library to interface with the pkdgrav3 N-body code.
+ */
+
+#include "pkdgrav3interface.h"
+
+#ifdef PKDGRAV3INTERFACE
+
+int InitVelociraptor(char* configname, unitinfo u, siminfo s, const int numthreads)
+{
+    std::cout << "hello world from velociraptor: InitVelociraptor" << std::endl;
+    return 0;
+}
+
+vr_return_data InvokeVelociraptor(const int snapnum, char* outputname,
+    cosmoinfo c, siminfo s,
+    const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
+    struct pkdgrav3_vel_part *pkdgrav_parts, int *cell_node_ids,
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound)
+{
+    std::cout << "hello world from velociraptor: InvokeVelociraptor" << std::endl;
+    vr_return_data data{};
+    return data;
+}
+
+void SetVelociraptorSimulationState(cosmoinfo c, siminfo s)
+{
+    std::cout << "hello world from velociraptor: SetVelociraptorSimulationState" << std::endl;
+}
+
+#endif

--- a/src/pkdgrav3interface.h
+++ b/src/pkdgrav3interface.h
@@ -1,0 +1,106 @@
+/*! \file pkdgrav3interface.h
+ *  \brief this file contains definitions and routines for interfacing with pkdgrav3
+ */
+
+#ifndef PKDGRAV3INTERFACE_H
+#define PKDGRAV3INTERFACE_H
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cmath>
+#include <string>
+#include <getopt.h>
+#include <sys/stat.h>
+
+#ifdef USEMPI
+#include <mpi.h>
+#endif
+
+// include the options structure via allvars
+#include "allvars.h"
+#include "proto.h"
+
+///\name Include for NBodyFramework library.
+//@{
+#include <NBody.h>
+#include <NBodyMath.h>
+#include <KDTree.h>
+//@}
+
+using namespace std;
+using namespace Math;
+using namespace NBody;
+
+#ifdef PKDGRAV3INTERFACE
+
+///structure for interfacing with pkdgrav3 and extract cosmological information
+namespace Pkdgrav3 {
+    /// store basic cosmological information
+    struct cosmoinfo {
+      double atime;
+      double littleh;
+      double Omega_m;
+      double Omega_r;
+      double Omega_nu;
+      double Omega_k;
+      double Omega_b;
+      double Omega_Lambda;
+      double Omega_cdm;
+      double w_de;
+    };
+    ///structure to store unit information
+    struct unitinfo {
+        double lengthtokpc,velocitytokms,masstosolarmass,energyperunitmass,gravity,hubbleunit;
+    };
+
+    struct cell_loc {
+        double loc[3];
+    };
+
+    ///store simulation info
+    struct siminfo {
+        double period, zoomhigresolutionmass, interparticlespacing, spacedimension[3];
+        int numcells;
+        int numcellsperdim;
+        cell_loc *cellloc;
+        double cellwidth[3];
+        double icellwidth[3];
+        int *cellnodeids;
+        int icosmologicalsim;
+        int izoomsim;
+        int idarkmatter, igas, istar, ibh, iother;
+#ifdef NOMASS
+        double mass_uniform_box;
+#endif
+    };
+
+    struct groupinfo {
+      int index;
+      long long groupid;
+    };
+
+    struct vr_return_data {
+      int num_gparts_in_groups;
+      struct groupinfo *group_info;
+      int num_most_bound;
+      int *most_bound_index;
+    };
+}
+
+struct pkdgrav3_vel_part;
+
+using namespace Pkdgrav3;
+
+extern "C" int InitVelociraptor(char* configname, Pkdgrav3::unitinfo, Pkdgrav3::siminfo, const int numthreads);
+extern "C" Pkdgrav3::vr_return_data InvokeVelociraptor(const int snapnum, char* outputname,
+    Pkdgrav3::cosmoinfo, Pkdgrav3::siminfo,
+    const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
+    struct pkdgrav3_vel_part *pkdgrav_parts, int *cell_node_ids,
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound);
+void SetVelociraptorSimulationState(Pkdgrav3::cosmoinfo, Pkdgrav3::siminfo);
+#endif
+
+#endif


### PR DESCRIPTION
## Summary
- scaffold pkdgrav3 interface and placeholder functions
- add `VR_USE_PKDGRAV3_INTERFACE` build option
- document pkdgrav3 library build option and mention interface in docs

## Testing
- `cmake -DVR_USE_PKDGRAV3_INTERFACE=ON ..` *(fails: unable to clone submodules)*

------
https://chatgpt.com/codex/tasks/task_e_68c08100f6b883249bfdc7a5456c66e5