### PR TITLE
Add pkdgrav3 interface skeleton

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ set(VR_SOURCES
     ramsesio.cxx
     search.cxx
     swiftinterface.cxx
+    pkdgrav3interface.cxx
     substructureproperties.cxx
     tipsyio.cxx
     ui.cxx

--- a/src/pkdgrav3interface.cxx
+++ b/src/pkdgrav3interface.cxx
@@ -1,0 +1,29 @@
+/*! \file pkdgrav3interface.cxx
+ *  \brief this file contains routines that allow the velociraptor library to interface with the pkdgrav3 N-body code.
+ */
+
+#include "ioutils.h"
+#include "logging.h"
+#include "pkdgrav3interface.h"
+#include "timer.h"
+
+#ifdef PKDGRAV3INTERFACE
+
+Options libvelociraptorOpt;
+Options libvelociraptorOptbackup;
+
+/// \defgroup PKDGRAV3CONFIGERRORS Errors for pkdgrav3
+//@{
+#define PKDGRAV3CONFIGOPTMISSING 8
+#define PKDGRAV3CONFIGOPTERROR 9
+#define PKDGRAV3CONFIGOPTCONFLICT 10
+//@}
+
+///check configuration options with pkdgrav3
+inline int ConfigCheckPkdgrav3(Options &opt, Pkdgrav3::siminfo &s)
+{
+    std::cout << "hello world from config ConfigCheckPkdgrav3" << std::endl;
+    return 1;
+}
+
+#endif // PKDGRAV3INTERFACE

--- a/src/pkdgrav3interface.h
+++ b/src/pkdgrav3interface.h
@@ -1,0 +1,38 @@
+/*! \file pkdgrav3interface.h
+ *  \brief this file contains definitions and routines for interfacing with pkdgrav3
+ */
+
+#ifndef PKDGRAV3INTERFACE_H
+#define PKDGRAV3INTERFACE_H
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cmath>
+#include <string>
+#include <getopt.h>
+#include <sys/stat.h>
+
+#ifdef USEMPI
+#include <mpi.h>
+#endif
+
+///include the options structure via allvars
+#include "allvars.h"
+#include "proto.h"
+
+#ifdef PKDGRAV3INTERFACE
+
+///structure for interfacing with pkdgrav3 and extract simulation information
+namespace Pkdgrav3 {
+    ///store simulation info
+    struct siminfo {
+        int dummy; ///< placeholder for simulation information
+    };
+}
+
+#endif // PKDGRAV3INTERFACE
+
+#endif // PKDGRAV3INTERFACE_H


### PR DESCRIPTION
## Summary
- add pkdgrav3 interface header and source with stub ConfigCheckPkdgrav3
- expose pkdgrav3 interface in build configuration

## Testing
- `cmake -S . -B build` *(fails: unable to clone submodules)*

------
https://chatgpt.com/codex/tasks/task_e_68c08df377c88324a370bb815267f3b1