### PR TITLE
Add pkdgrav3 configuration placeholders

### DIFF
--- a/src/pkdgrav3interface.cxx
+++ b/src/pkdgrav3interface.cxx
@@ -6,6 +6,22 @@
 
 #ifdef PKDGRAV3INTERFACE
 
+Options libvelociraptorOpt;
+Options libvelociraptorOptbackup;
+
+/// \defgroup PKDGRAV3CONFIGERRORS Errors for pkdgrav3
+//@{
+#define PKDGRAV3CONFIGOPTMISSING 8
+#define PKDGRAV3CONFIGOPTERROR 9
+#define PKDGRAV3CONFIGOPTCONFLICT 10
+//@}
+
+inline int ConfigCheckPkdgrav3(Options &opt, Pkdgrav3::siminfo &s)
+{
+    std::cout << "hello world from config ConfigCheckPkdgrav3" << std::endl;
+    return 1;
+}
+
 int InitVelociraptor(char* configname, unitinfo u, siminfo s, const int numthreads)
 {
     std::cout << "hello world from velociraptor: InitVelociraptor" << std::endl;

--- a/src/pkdgrav3interface.h
+++ b/src/pkdgrav3interface.h
@@ -94,6 +94,10 @@ struct pkdgrav3_vel_part;
 
 using namespace Pkdgrav3;
 
+///global libvelociraptorOptions structure that is used when calling library velociraptor from pkdgrav3
+extern Options libvelociraptorOpt;
+extern Options libvelociraptorOptbackup;
+
 extern "C" int InitVelociraptor(char* configname, Pkdgrav3::unitinfo, Pkdgrav3::siminfo, const int numthreads);
 extern "C" Pkdgrav3::vr_return_data InvokeVelociraptor(const int snapnum, char* outputname,
     Pkdgrav3::cosmoinfo, Pkdgrav3::siminfo,


### PR DESCRIPTION
## Summary
- expose libvelociraptor option symbols for pkdgrav3 interface
- add placeholder config check and error codes for pkdgrav3

## Testing
- `cmake .. && make test` *(fails: unable to clone submodules)*

------
https://chatgpt.com/codex/tasks/task_e_68c090258c448324bae82a44c550bb7c