### PR TITLE
Add PKDGRAV3 interface guards

### DIFF
--- a/src/allvars.cxx
+++ b/src/allvars.cxx
@@ -460,7 +460,7 @@ if (opt.iextragasoutput) {
         }
     }
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     /*writing M_gas_highT and other related quantities*/
     val=M_gas_highT;
     Fout.write((char*)&val,sizeof(val));
@@ -686,7 +686,7 @@ if (opt.iextragasoutput) {
         for (auto j=0;j<opt.aperturenum;j++) {
             Fout.write((char*)&aperture_Z_star[j],sizeof(val));
         }
-	#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+	#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
         for (auto j=0;j<opt.aperturenum;j++) {
             Fout.write((char*)&aperture_M_gas_highT[j],sizeof(val));
         }
@@ -1126,7 +1126,7 @@ if (opt.iextragasoutput) {
     }
 
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     Fout<<M_gas_highT<<" ";
     Fout<<Temp_mean_gas_highT<<" ";
     Fout<<Z_mean_gas_highT<<" ";
@@ -1320,7 +1320,7 @@ if (opt.iextragasoutput) {
         for (auto j=0;j<opt.aperturenum;j++) {
             Fout<<aperture_Z_star[j]<<" ";
         }
-        #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+        #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
         for (auto j=0;j<opt.aperturenum;j++) {
             Fout<<aperture_M_gas_highT[j]<<" ";
         }
@@ -1881,7 +1881,7 @@ void PropDataHeader::declare_all_datasets(const Options &opt)
     }
 #endif // defined(GASON) && defined(STARON)
 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     declare_dataset("Mass_gas_highT_excl", MASS);
     declare_dataset("T_gas_highT_excl", TEMPERATURE);
     declare_dataset("Zmet_gas_highT_excl");
@@ -1916,7 +1916,7 @@ void PropDataHeader::declare_all_datasets(const Options &opt)
             declare_dataset(name.str());
         }
     }
-#endif // (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#endif // (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 
     declare_dataset("Mass_tot_incl", MASS);
 
@@ -2033,11 +2033,11 @@ void PropDataHeader::declare_all_datasets(const Options &opt)
         declare_aperture_datasets("Zmet_gas_sf");
         declare_aperture_datasets("Zmet_gas_nsf");
         declare_aperture_datasets("Zmet_star");
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
         declare_aperture_datasets("mass_highT", MASS);
         declare_aperture_datasets("T_highT", TEMPERATURE);
         declare_aperture_datasets("Zmet_highT");
-#endif // (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#endif // (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 #endif // defined(GASON) && defined(STARON)
 
         //add extra property data in apertures

--- a/src/allvars.h
+++ b/src/allvars.h
@@ -788,11 +788,11 @@ struct Options
     vector<unsigned long long> cellnodenumparts;
 
     /// allowed mesh based mpi decomposition load imbalance
-#ifndef SWIFTINTERFACE
+#if !defined(SWIFTINTERFACE) && !defined(PKDGRAV3INTERFACE)
     float mpimeshimbalancelimit = 0.1;
 #else
     float mpimeshimbalancelimit = 0;
-#endif // SWIFTINTERFACE
+#endif // SWIFTINTERFACE || PKDGRAV3INTERFACE
 
     ///whether using mesh decomposition
     bool impiusemesh = true;
@@ -1535,7 +1535,7 @@ struct PropData
     vector<float> profile_mass_gas_nsf;
     vector<float> profile_mass_inclusive_gas_nsf;
     vector<Coordinate> profile_L_gas_nsf;
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     vector<float> aperture_M_gas_highT;
     vector<float> aperture_Temp_mean_gas_highT;
     vector<float> aperture_Z_mean_gas_highT;
@@ -1547,7 +1547,7 @@ struct PropData
     vector<Coordinate> SO_angularmomentum_gas_nsf;
 #endif
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     Double_t M_gas_highT;
     Double_t Temp_mean_gas_highT;
     Double_t Z_mean_gas_highT;
@@ -1798,7 +1798,7 @@ struct PropData
         L_BN98_excl_gas_nsf[0]=L_BN98_excl_gas_nsf[1]=L_BN98_excl_gas_nsf[2]=0;
 #endif
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	M_gas_highT=0;
 	Temp_mean_gas_highT=0;
 	Z_mean_gas_highT=0;
@@ -1857,7 +1857,7 @@ struct PropData
         AllocateApertures(opt);
         AllocateProfiles(opt);
         AllocateSOs(opt);
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	AllocateSOs_HotGas(opt);
 #endif
     }
@@ -1891,7 +1891,7 @@ struct PropData
             aperture_rhalfmass_gas_nsf.resize(opt.aperturenum);
             aperture_Z_gas_sf.resize(opt.aperturenum);
             aperture_Z_gas_nsf.resize(opt.aperturenum);
-            #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+            #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	    aperture_M_gas_highT.resize(opt.aperturenum);
 	    aperture_Temp_mean_gas_highT.resize(opt.aperturenum);
 	    aperture_Z_mean_gas_highT.resize(opt.aperturenum);
@@ -1953,7 +1953,7 @@ struct PropData
             for (auto &x:aperture_rhalfmass_gas_nsf) x=-1;
             for (auto &x:aperture_Z_gas_sf) x=0;
             for (auto &x:aperture_Z_gas_nsf) x=0;
-            #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+            #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
             for (auto &x:aperture_M_gas_highT) x=0;
             for (auto &x:aperture_Temp_mean_gas_highT) x=0;
             for (auto &x:aperture_Z_mean_gas_highT) x=0;
@@ -2128,7 +2128,7 @@ struct PropData
         }
     }
 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     void AllocateSOs_HotGas(Options &opt)
     {
         int sonum_hotgas = opt.aperture_hotgas_normalised_to_overdensity.size();
@@ -2287,7 +2287,7 @@ struct PropData
         #endif
 
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	M_gas_highT*=opt.h;
 	M_gas_highT_incl*=opt.h;
         if(opt.aperture_hotgas_normalised_to_overdensity.size() > 0){

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -2335,7 +2335,7 @@ void WriteProperties(Options &opt, const Int_t ngroups, PropData *pdata){
         }
     }
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     /*writing M_gas_highT and related quantities*/
     for (Int_t i=0;i<ngroups;i++) ((Double_t*)data)[i]=pdata[i+1].M_gas_highT;
     Fhdf.write_dataset(opt, head.headerdatainfo[itemp],ng,data,head.hdfpredtypeinfo[itemp]);itemp++;
@@ -2628,7 +2628,7 @@ void WriteProperties(Options &opt, const Int_t ngroups, PropData *pdata){
                 Fhdf.write_dataset(opt, head.headerdatainfo[itemp],ng,data,head.hdfpredtypeinfo[itemp]);itemp++;
             }
 
-            #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+            #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
             for (auto j=0;j<opt.aperturenum;j++) {
                 for (Int_t i=0;i<ngroups;i++) ((Double_t*)data)[i]=pdata[i+1].aperture_M_gas_highT[j];
                 Fhdf.write_dataset(opt, head.headerdatainfo[itemp],ng,data,head.hdfpredtypeinfo[itemp]);itemp++;

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -106,8 +106,12 @@ int run(int argc,char **argv)
 
     show_version_info(argc, argv);
 
-#if defined(SWIFTINTERFACE) || defined(PKDGRAV3INTERFACE)
-    cout<<"Built with interface enabled when running standalone VELOCIraptor. Should only be enabled when running VELOCIraptor as a library. Exiting..."<<endl;
+#ifdef SWIFTINTERFACE
+    cout<<"Built with SWIFT interface enabled when running standalone VELOCIraptor. Should only be enabled when running VELOCIraptor as a library from SWIFT. Exiting..."<<endl;
+    exit(0);
+#endif
+#ifdef PKDGRAV3INTERFACE
+    cout<<"Built with PKDGRAV3 interface enabled when running standalone VELOCIraptor. Should only be enabled when running VELOCIraptor as a library from PKDGRAV3. Exiting..."<<endl;
     exit(0);
 #endif
 

--- a/src/mpiroutines.cxx
+++ b/src/mpiroutines.cxx
@@ -20,6 +20,9 @@
 #ifdef SWIFTINTERFACE
 #include "swiftinterface.h"
 using namespace Swift;
+#elif defined(PKDGRAV3INTERFACE)
+#include "pkdgrav3interface.h"
+using namespace Pkdgrav3;
 #endif
 
 /// function that sends information between threads 

--- a/src/mpiroutines.cxx
+++ b/src/mpiroutines.cxx
@@ -22,7 +22,6 @@
 using namespace Swift;
 #elif defined(PKDGRAV3INTERFACE)
 #include "pkdgrav3interface.h"
-using namespace Pkdgrav3;
 #endif
 
 /// function that sends information between threads 

--- a/src/pkdgrav3interface.cxx
+++ b/src/pkdgrav3interface.cxx
@@ -67,7 +67,9 @@ inline int ConfigCheckPkdgrav3(Options &opt, Pkdgrav3::siminfo &s)
     return 1;
 }
 
-int InitVelociraptor(Options &opt, const char* configname, unitinfo u, siminfo s, const int numthreads)
+int InitVelociraptor(Options &opt, const char* configname,
+                     Pkdgrav3::unitinfo u, Pkdgrav3::siminfo s,
+                     const int numthreads)
 {
     // if mpi invoked, init the velociraptor tasks and openmp threads
 #ifdef USEMPI
@@ -151,23 +153,27 @@ int InitVelociraptor(Options &opt, const char* configname, unitinfo u, siminfo s
 
 }
 
-int InitVelociraptor(const char* configname, unitinfo u, siminfo s, const int numthreads)
+int InitVelociraptor(const char* configname, Pkdgrav3::unitinfo u,
+                     Pkdgrav3::siminfo s, const int numthreads)
 {
     return InitVelociraptor(libvelociraptorOpt, configname, u, s, numthreads);
 }
 
-vr_return_data InvokeVelociraptor(const int snapnum, char* outputname,
-    cosmoinfo c, siminfo s,
-    const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
+Pkdgrav3::vr_return_data InvokeVelociraptor(
+    const int snapnum, char* outputname, Pkdgrav3::cosmoinfo c,
+    Pkdgrav3::siminfo s, const size_t num_gravity_parts,
+    const size_t num_hydro_parts, const size_t num_star_parts,
     struct pkdgrav3_vel_part *pkdgrav_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound)
+    const int numthreads, const int ireturngroupinfoflag,
+    const int ireturnmostbound)
 {
     std::cout << "hello world from velociraptor: InvokeVelociraptor" << std::endl;
-    vr_return_data data{};
+    Pkdgrav3::vr_return_data data{};
     return data;
 }
 
-void SetVelociraptorSimulationState(cosmoinfo c, siminfo s)
+void SetVelociraptorSimulationState(Pkdgrav3::cosmoinfo c,
+                                    Pkdgrav3::siminfo s)
 {
     std::cout << "hello world from velociraptor: SetVelociraptorSimulationState" << std::endl;
 }

--- a/src/pkdgrav3interface.h
+++ b/src/pkdgrav3interface.h
@@ -91,18 +91,22 @@ namespace Pkdgrav3 {
 }
 
 struct pkdgrav3_vel_part;
-
-using namespace Pkdgrav3;
-
 extern Options libvelociraptorOpt;
-int InitVelociraptor(Options &opt, const char* configname, unitinfo u, siminfo s, const int numthreads);
-extern "C" int InitVelociraptor(const char* configname, unitinfo u, siminfo s, const int numthreads);
-extern "C" vr_return_data InvokeVelociraptor(const int snapnum, char* outputname,
-    cosmoinfo c, siminfo s,
-    const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
+int InitVelociraptor(Options &opt, const char* configname,
+                     Pkdgrav3::unitinfo u, Pkdgrav3::siminfo s,
+                     const int numthreads);
+extern "C" int InitVelociraptor(const char* configname,
+                                 Pkdgrav3::unitinfo u, Pkdgrav3::siminfo s,
+                                 const int numthreads);
+extern "C" Pkdgrav3::vr_return_data InvokeVelociraptor(
+    const int snapnum, char* outputname, Pkdgrav3::cosmoinfo c,
+    Pkdgrav3::siminfo s, const size_t num_gravity_parts,
+    const size_t num_hydro_parts, const size_t num_star_parts,
     struct pkdgrav3_vel_part *pkdgrav_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound);
-void SetVelociraptorSimulationState(cosmoinfo c, siminfo s);
+    const int numthreads, const int ireturngroupinfoflag,
+    const int ireturnmostbound);
+void SetVelociraptorSimulationState(Pkdgrav3::cosmoinfo c,
+                                    Pkdgrav3::siminfo s);
 #endif
 
 #endif

--- a/src/proto.h
+++ b/src/proto.h
@@ -440,7 +440,7 @@ void CalculateSphericalOverdensityExclusive(Options &opt, PropData &pdata,
 void CalculateExtraSphericalOverdensityProperties(Options &opt, PropData &pdata,
     vector<Double_t> &radii, vector<Double_t> &masses, vector<Int_t> &indices,
     vector<Coordinate> &posparts, vector<Coordinate> &velparts, 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     vector<int> &typeparts, int sonum_hotgas, int SOthreshNorm, 
     vector<Double_t> &temp, vector<Double_t> &sfr, vector<Double_t> &Zgas);
 #else

--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -624,7 +624,7 @@ private(EncMassSF,EncMassNSF,Krot_sf,Krot_nsf,Ekin_sf,Ekin_nsf)
                     pdata[i].Z_gas_nsf+=Pval->GetZmet();
                     pdata[i].Z_mean_gas_nsf+=mval*Pval->GetZmet();
                 }
-        		#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+        		#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
                 if(j == 0 & opt.iverbose>1){
                     LOG(debug) << "Gas temperature of particle 1 in this object " << temp << " for gas and threshold " << opt.temp_max_cut;
                 }
@@ -696,7 +696,7 @@ private(EncMassSF,EncMassNSF,Krot_sf,Krot_nsf,Ekin_sf,Ekin_nsf)
             }
 #endif
         }
-	#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+	#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	if(pdata[i].M_gas_highT>0){
 	    pdata[i].Temp_mean_gas_highT/=pdata[i].M_gas_highT;
 	    pdata[i].Z_mean_gas_highT/=pdata[i].M_gas_highT;
@@ -1451,7 +1451,7 @@ private(j,Pval,mval,x,y,z,vx,vy,vz,jval,jzval,zdist,Rdist)
                 if (SFR>opt.gas_sfr_threshold) pdata[i].M_gas_sf+=mval;
                 else pdata[i].M_gas_nsf+=mval;
                 #endif
-                #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+                #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
                 auto temp = Pval->GetTemperature();
                 if (temp > opt.temp_max_cut && SFR <= 0) {
                     pdata[i].M_gas_highT+=mval;
@@ -1538,7 +1538,7 @@ private(j,Pval,x,y,z,vx,vy,vz,J,mval,SFR)
                     sigV_gas_nsf+=(vx*vx+vy*vy*vz*vz)*mval;
                 }
 
-                #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+                #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
                 /*select hot gas particles and add up their mass and compute mass-weighted quantities*/
                 if (temp > opt.temp_max_cut && SFR <= 0) {
                     Tsum_hot+=mval*temp;
@@ -1574,7 +1574,7 @@ private(j,Pval,x,y,z,vx,vy,vz,J,mval,SFR)
         pdata[i].Z_gas_nsf=Zsum_nsf;
         pdata[i].Z_mean_gas_nsf=Zmeansum_nsf;
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
         pdata[i].Temp_mean_gas_highT=Tsum_hot;
         pdata[i].Z_mean_gas_highT=Zsum_hot;
 #endif
@@ -1614,7 +1614,7 @@ private(j,Pval,x,y,z,vx,vy,vz,J,mval,SFR)
             }
 #endif
         }
-        #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+        #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
         if(pdata[i].M_gas_highT>0){
             pdata[i].Temp_mean_gas_highT/=pdata[i].M_gas_highT;
             pdata[i].Z_mean_gas_highT/=pdata[i].M_gas_highT;
@@ -3091,7 +3091,7 @@ private(i,j,k)
 		      pdata[i].M_gas_nsf_incl += massval;
 		   }
 #endif // STARON
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 		   auto temp = Pval->GetTemperature();
                    /*select hot gas particles and add up their mass and compute mass-weighted quantities*/
                    if (temp > opt.temp_max_cut && sfr <= 0) {
@@ -3114,7 +3114,7 @@ private(i,j,k)
 #ifdef NOMASS
         pdata[i].gMFOF*=opt.MassValue;
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	if(pdata[i].M_gas_highT_incl > 0){
 		pdata[i].Temp_mean_gas_highT_incl /= pdata[i].M_gas_highT_incl;
 		pdata[i].Z_mean_gas_highT_incl /= pdata[i].M_gas_highT_incl;
@@ -3157,7 +3157,7 @@ void GetFOFMass(Options &opt, Int_t ngroup, Int_t *&numingroup, PropData *&pdata
 #ifdef STARON
 	    pdata[hostindex].M_star_incl += pdata[i].M_star;
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	    pdata[hostindex].M_gas_highT_incl += pdata[i].M_gas_highT;
 	    pdata[hostindex].Temp_mean_gas_highT_incl += pdata[i].Temp_mean_gas_highT * pdata[i].M_gas_highT;
 	    pdata[hostindex].Z_mean_gas_highT_incl += pdata[i].Z_mean_gas_highT * pdata[i].M_gas_highT;
@@ -3177,7 +3177,7 @@ void GetFOFMass(Options &opt, Int_t ngroup, Int_t *&numingroup, PropData *&pdata
 #ifdef STARON
             pdata[i].M_star_incl += pdata[i].M_star;
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
             pdata[i].M_gas_highT_incl += pdata[i].M_gas_highT;
             pdata[i].Temp_mean_gas_highT_incl += pdata[i].Temp_mean_gas_highT * pdata[i].M_gas_highT;
             pdata[i].Z_mean_gas_highT_incl += pdata[i].Z_mean_gas_highT * pdata[i].M_gas_highT;
@@ -3187,7 +3187,7 @@ void GetFOFMass(Options &opt, Int_t ngroup, Int_t *&numingroup, PropData *&pdata
 #ifdef NOMASS
     for (i=1;i<=ngroup;i++) pdata[i].gMFOF*=opt.MassValue;
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     for (i=1;i<=ngroup;i++) {
 	if(pdata[i].M_gas_highT_incl > 0){
 		pdata[i].Temp_mean_gas_highT_incl /= pdata[i].M_gas_highT_incl;
@@ -3235,7 +3235,7 @@ void GetSOMasses(Options &opt, const Int_t nbodies, Particle *Part, Int_t ngroup
         }
     }
 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     int sonum_hotgas = opt.aperture_hotgas_normalised_to_overdensity.size();
     auto iter = std::find(opt.SOthresholds_values_crit.begin(), opt.SOthresholds_values_crit.end(), opt.hot_gas_overdensity_normalisation);
     int SOthreshNorm;
@@ -3368,7 +3368,7 @@ private(i,j,k,taggedparts,radii,masses,indices,posref,posparts,velparts,typepart
     }
 #endif
 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
         vector<Double_t> temp;
 #ifdef STARON
         vector<Double_t> sfr;
@@ -3399,7 +3399,7 @@ private(i,j,k,taggedparts,radii,masses,indices,posref,posparts,velparts,typepart
                 typeparts[j]=Part[taggedparts[j]].GetType();
             }
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
            if (sonum_hotgas > 0 && typeparts[j] == GASTYPE) {
                temp[j] = Part[taggedparts[j]].GetTemperature();
 #ifdef STARON
@@ -3445,7 +3445,7 @@ private(i,j,k,taggedparts,radii,masses,indices,posref,posparts,velparts,typepart
                         typeparts.resize(typeparts.size()+taggedparts.size());
                     }
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
                    if (sonum_hotgas > 0) {
                        temp.resize(typeparts.size()+taggedparts.size());
 #ifdef STARON
@@ -3471,7 +3471,7 @@ private(i,j,k,taggedparts,radii,masses,indices,posref,posparts,velparts,typepart
                             typeparts[offset+j]=PartDataGet[taggedparts[j]].GetType();
                         }
 #endif
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
                         if (sonum_hotgas > 0 && typeparts[offset+j] == GASTYPE) {
                             temp[offset+j] = PartDataGet[taggedparts[j]].GetTemperature();
 #ifdef STARON
@@ -3514,7 +3514,7 @@ private(i,j,k,taggedparts,radii,masses,indices,posref,posparts,velparts,typepart
         //calculate other extra SO related properties
         CalculateExtraSphericalOverdensityProperties(opt, pdata[i], 
         radii, masses, indices, posparts, velparts, 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
         typeparts, sonum_hotgas, SOthreshNorm, temp, sfr, Zgas);
 #else
         typeparts);
@@ -4530,7 +4530,7 @@ private(i,j,k,storepid)
     }
 
     }//end of if calculate potential
-#ifdef SWIFTINTERFACE
+#if defined(SWIFTINTERFACE) || defined(PKDGRAV3INTERFACE)
     else {
         for (i=1;i<=ngroup;i++) for (j=0;j<numingroup[i];j++) Part[j+noffset[i]].SetPotential(Part[j+noffset[i]].GetGravityPotential());
     }
@@ -5374,7 +5374,7 @@ void CalculateApertureQuantities(Options &opt, Int_t &ning, Particle *Part, Prop
         float mass, mass_sf, mass_nsf;
 #if defined(GASON) && defined(STARON)
         float SFR, Zmet;
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	float temp;
 #endif
 #endif
@@ -5395,7 +5395,7 @@ void CalculateApertureQuantities(Options &opt, Int_t &ning, Particle *Part, Prop
 #if defined(GASON) && defined(STARON)
         SFR = Pval->GetSFR();
         Zmet = Pval->GetZmet()*mass;
-	#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+	#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	temp = Pval->GetTemperature();
 	#endif
 #endif
@@ -5424,7 +5424,7 @@ void CalculateApertureQuantities(Options &opt, Int_t &ning, Particle *Part, Prop
             if (EncMassGasNSF>0) pdata.aperture_veldisp_gas_nsf[iaptindex]=EncVelDispGasNSF/EncMassGasNSF;
             if (EncMassGasSF>0) pdata.aperture_vrdisp_gas_sf[iaptindex]=EncVRDispGasSF/EncMassGasSF;
             if (EncMassGasNSF>0) pdata.aperture_vrdisp_gas_nsf[iaptindex]=EncVRDispGasNSF/EncMassGasNSF;
-	    #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+	    #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	    pdata.aperture_M_gas_highT[iaptindex]=EncMassGasHot;
 	    if(EncMassGasHot>0){
 		   pdata.aperture_Temp_mean_gas_highT[iaptindex]=EncTGasHot/EncMassGasHot;
@@ -5519,7 +5519,7 @@ void CalculateApertureQuantities(Options &opt, Int_t &ning, Particle *Part, Prop
                 EncVRDispGasNSF += vrdisp;
                 EncZmetGasNSF += Zmet;
             }
-            #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+            #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
 	    // compute aperture quantities related to hot gas.
 	    if(temp > opt.temp_max_cut && SFR <= 0){
                EncMassGasHot += mass;
@@ -5613,7 +5613,7 @@ void CalculateApertureQuantities(Options &opt, Int_t &ning, Particle *Part, Prop
         if (EncMassGasNSF>0) pdata.aperture_veldisp_gas_nsf[j]=EncVelDispGasNSF/EncMassGasNSF;
         if (EncMassGasNSF>0) pdata.aperture_vrdisp_gas_nsf[j]=EncVRDispGasNSF/EncMassGasNSF;
         if (EncMassGasNSF>0) pdata.aperture_Z_gas_nsf[j]=EncZmetGasNSF/EncMassGasNSF;
-        #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+        #if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
         pdata.aperture_M_gas_highT[j]=EncMassGasHot;
 	if(EncMassGasHot>0){
 	   pdata.aperture_Temp_mean_gas_highT[j]=EncTGasHot/EncMassGasHot;
@@ -7306,7 +7306,7 @@ void SetSphericalOverdensityMasstoTotalMassExclusive(Options &opt, PropData &pda
 void CalculateExtraSphericalOverdensityProperties(Options &opt, PropData &pdata,
     vector<Double_t> &radii, vector<Double_t> &masses, vector<Int_t> &indices,
     vector<Coordinate> &posparts, vector<Coordinate> &velparts, 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     vector<int> &typeparts, int sonum_hotgas, int SOthreshNorm, 
     vector<Double_t> &temp, vector<Double_t> &sfr, vector<Double_t> &Zgas)
 #else 
@@ -7317,7 +7317,7 @@ void CalculateExtraSphericalOverdensityProperties(Options &opt, PropData &pdata,
     if (!opt.iextrahalooutput) return;
 
 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     // define the radii in which we'll evaluate the mass of hot gas and relates quantities.
     vector<Double_t> SOlg_radii_highT(sonum_hotgas);
     std::transform(opt.aperture_hotgas_normalised_to_overdensity.begin(),
@@ -7412,7 +7412,7 @@ void CalculateExtraSphericalOverdensityProperties(Options &opt, PropData &pdata,
                     pdata.SO_mass_gas[iso]+=massval;
                     pdata.SO_angularmomentum_gas[iso]+=J;
                 }
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
                 if(sonum_hotgas > 0){
                     for (int r_ap = 0; r_ap < sonum_hotgas; r_ap++){
                         if(rc < SOlg_radii_highT[r_ap]){
@@ -7477,7 +7477,7 @@ void CalculateExtraSphericalOverdensityProperties(Options &opt, PropData &pdata,
 #endif
     }
 
-#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE))
+#if (defined(GASON)) || (defined(GASON) && defined(SWIFTINTERFACE)) || (defined(GASON) && defined(PKDGRAV3INTERFACE))
     // normalize vectors by mass.
     if(pdata.M_gas_highT_incl)
     {

--- a/src/ui.cxx
+++ b/src/ui.cxx
@@ -786,7 +786,7 @@ void GetParamFile(Options &opt)
                 }
             }
         }
-#ifndef SWIFTINTERFACE
+#if !defined(SWIFTINTERFACE) && !defined(PKDGRAV3INTERFACE)
         if (opt.outname==NULL) {
             if (ThisTask==0)
                 cerr<<"No output name given, terminating"<<endl;
@@ -2704,6 +2704,9 @@ ConfigInfo::ConfigInfo(Options &opt){
 #endif
 #ifdef SWIFTINTERFACE
     AddEntry("#SWIFTINTERFACE");
+#endif
+#ifdef PKDGRAV3INTERFACE
+    AddEntry("#PKDGRAV3INTERFACE");
 #endif
 
 }

--- a/src/unbind.cxx
+++ b/src/unbind.cxx
@@ -795,7 +795,7 @@ int Unbind(Options &opt, Particle **gPart, Int_t &numgroups, Int_t *numingroup, 
         if (opt.uinfo.icalculatepotential) {
             for (j=0;j<numingroup[i];j++) gPart[i][j].SetPotential(0);
         }
-        #ifdef SWIFTINTERFACE
+        #if defined(SWIFTINTERFACE) || defined(PKDGRAV3INTERFACE)
         else {
             for (j=0;j<numingroup[i];j++) gPart[i][j].SetPotential(gPart[i][j].GetGravityPotential());
         }


### PR DESCRIPTION
## Summary
- handle standalone runs when PKDGRAV3 interface is enabled
- propagate PKDGRAV3 interface checks alongside SWIFT interface handling

## Testing
- `cmake -S . -B build` *(fails: git submodule update --init failed with 1, please checkout submodules)*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68c1615c0b988324988569c67dc6ac93