### PR TITLE
Add pkdgrav3 interface stubs and cmake flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,10 @@ set(VR_SOURCES
     vr_exceptions.cxx
 )
 
+if (VR_USE_PKDGRAV3_INTERFACE)
+    list(APPEND VR_SOURCES pkdgrav3interface.cxx)
+endif()
+
 add_library(velociraptor STATIC ${VR_SOURCES})
 target_compile_definitions(velociraptor PUBLIC ${VR_DEFINES})
 if (VR_CXX_FLAGS)

--- a/src/pkdgrav3interface.cxx
+++ b/src/pkdgrav3interface.cxx
@@ -1,0 +1,21 @@
+/*! \file pkdgrav3interface.cxx
+ *  \brief this file contains stub routines that allow VELOCIraptor to interface with the pkdgrav3 N-body code.
+ */
+
+#include "pkdgrav3interface.h"
+
+#ifdef PKDGRAV3INTERFACE
+
+int InitVelociraptorPKD()
+{
+    // Placeholder initialisation for pkdgrav3 interface
+    return 0;
+}
+
+int InvokeVelociraptorPKD()
+{
+    // Placeholder invocation for pkdgrav3 interface
+    return 0;
+}
+
+#endif

--- a/src/pkdgrav3interface.h
+++ b/src/pkdgrav3interface.h
@@ -1,0 +1,19 @@
+/*! \file pkdgrav3interface.h
+ *  \brief this file contains definitions and routines for interfacing with the pkdgrav3 N-body code.
+ */
+
+#ifndef PKDGRAV3INTERFACE_H
+#define PKDGRAV3INTERFACE_H
+
+#include "allvars.h"
+#include "proto.h"
+
+#ifdef PKDGRAV3INTERFACE
+/// Initialise VELOCIraptor when called from pkdgrav3.
+extern "C" int InitVelociraptorPKD();
+
+/// Invoke VELOCIraptor from pkdgrav3.
+extern "C" int InvokeVelociraptorPKD();
+#endif
+
+#endif


### PR DESCRIPTION
## Summary
- Add initial pkdgrav3 interface header and source stubs
- Wire pkdgrav3 interface into build when `VR_USE_PKDGRAV3_INTERFACE` is enabled

## Testing
- ⚠️ `cmake .. -DVR_USE_PKDGRAV3_INTERFACE=ON` (fails: `git submodule update --init` cannot access NBodylib/tool submodules)


------
https://chatgpt.com/codex/tasks/task_e_68c2b8631af88324b250bf3b4c2eb41f